### PR TITLE
Timestamps and default location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ sysinfo.txt
 # Signing Alias
 /Assets/Scripts/Editor/PreloadSigningAlias.cs
 /Assets/Scripts/Editor/PreloadSigningAlias.cs.meta
+Assets/Editor Default Resources/ScreenShooter/ScreenShooterSettings.asset*

--- a/Assets/ScreenShooter/Editor/Configs/ReorderableConfigsList.cs
+++ b/Assets/ScreenShooter/Editor/Configs/ReorderableConfigsList.cs
@@ -35,17 +35,27 @@ namespace Borodar.ScreenShooter.Configs
             reorderableList.drawElementCallback = (position, index, isActive, isFocused) =>
             {
                 const float textWidth = 12f;
+                const float lableWidth = 32f;
+                const float boolWidth = 9f;
                 const float dimensionWidth = 45f;
                 const float typeWidth = 45f;
                 const float space = 10f;
 
                 var config = configsList[index];
-                var nameWidth = position.width - space - textWidth - 2*dimensionWidth - space - typeWidth;
+                var nameWidth = position.width - space - lableWidth - boolWidth - space - textWidth - 2*dimensionWidth - space - typeWidth;
 
                 position.y += 2;
                 position.width = nameWidth;
                 position.height -= 4;
                 config.Name = EditorGUI.TextField(position, config.Name);
+                
+                position.x += position.width;
+                position.width = lableWidth;
+                EditorGUI.LabelField(position, "Time");
+
+                position.x += position.width;
+                position.width = boolWidth;
+                config.AppendTimestamp = EditorGUI.Toggle(position, config.AppendTimestamp);
 
                 position.x += position.width + space;
                 position.width = dimensionWidth;

--- a/Assets/ScreenShooter/Editor/Configs/ScreenshotConfig.cs
+++ b/Assets/ScreenShooter/Editor/Configs/ScreenshotConfig.cs
@@ -23,6 +23,7 @@ namespace Borodar.ScreenShooter.Configs
         public int Width;
         public int Height;
         public Format Type;
+        public bool AppendTimestamp;
 
         public ScreenshotConfig() {}
 

--- a/Assets/ScreenShooter/Editor/ScreenShooterSettings.cs
+++ b/Assets/ScreenShooter/Editor/ScreenShooterSettings.cs
@@ -29,7 +29,7 @@ namespace Borodar.ScreenShooter
         public Camera Camera = Camera.main;
         public List<ScreenshotConfig> ScreenshotConfigs;
         public string Tag;
-        public string SaveFolder = Application.dataPath + "/Screenshots";
+        public string SaveFolder;
 
         //---------------------------------------------------------------------
         // Public
@@ -51,6 +51,9 @@ namespace Borodar.ScreenShooter
                 new ScreenshotConfig("iPad Hi-Res Portrait", 1536, 2048, ScreenshotConfig.Format.PNG),
                 new ScreenshotConfig("4K UHD", 3840, 2160, ScreenshotConfig.Format.PNG)
             };
+
+            var assetPath = Application.dataPath;
+            settings.SaveFolder = assetPath.Remove(assetPath.LastIndexOf("Assets")) + "Screenshots";
 
             return settings;
         }

--- a/Assets/ScreenShooter/Editor/ScreenShooterWindow.cs
+++ b/Assets/ScreenShooter/Editor/ScreenShooterWindow.cs
@@ -51,17 +51,16 @@ namespace Borodar.ScreenShooter
         [MenuItem("Window/Screen Shooter")]
         protected static void ShowWindow()
         {
-            var window = (ScreenShooterWindow) GetWindow(typeof(ScreenShooterWindow));
+            var window = (ScreenShooterWindow)GetWindow(typeof(ScreenShooterWindow));
             window.autoRepaintOnSceneChange = true;
-            window.title = "Screen Shooter";
             window.Show();
         }
 
         protected void OnEnable()
         {
             var skinFolder = (EditorGUIUtility.isProSkin) ? "Professional/" : "Personal/";
-            _cameraIcon = (Texture2D) EditorGUIUtility.Load(ICONS_FOLDER + skinFolder + "CameraIcon.png");
-            _configsIcon = (Texture2D) EditorGUIUtility.Load(ICONS_FOLDER + skinFolder + "ConfigsIcon.png");
+            _cameraIcon = (Texture2D)EditorGUIUtility.Load(ICONS_FOLDER + skinFolder + "CameraIcon.png");
+            _configsIcon = (Texture2D)EditorGUIUtility.Load(ICONS_FOLDER + skinFolder + "ConfigsIcon.png");
             _folderIcon = (Texture2D)EditorGUIUtility.Load(ICONS_FOLDER + skinFolder + "FolderIcon.png");
 
             _takeButtonNormal = (Texture2D)EditorGUIUtility.Load(ICONS_FOLDER + skinFolder + "TakeButtonNormal.png");
@@ -74,6 +73,10 @@ namespace Borodar.ScreenShooter
 
             // Init reorderable list if required
             _list = _list ?? ReorderableConfigsList.Create(_settings.ScreenshotConfigs, MenuItemHandler);
+
+            // Setting title and icon in OnEnable (see http://docs.unity3d.com/ScriptReference/EditorWindow-titleContent.html)
+            titleContent.text = "Screen Shooter";
+            titleContent.image = _cameraIcon;
         }
 
         protected void OnGUI()

--- a/Assets/ScreenShooter/Editor/Util/ScreenshotUtil.cs
+++ b/Assets/ScreenShooter/Editor/Util/ScreenshotUtil.cs
@@ -63,13 +63,31 @@ namespace Borodar.ScreenShooter.Utils
             }
 
             var fileName = tag + screenshotConfig.Name + "." + screenshotConfig.Width + "x" + screenshotConfig.Height;
-            var imageFilePath = folder + "/" + MakeValidFileName(fileName + extension);
+            var imageFilePath = screenshotConfig.AppendTimestamp 
+                ? BuildFilePath(folder, fileName, DateTime.Now, extension)
+                : BuildFilePath(folder, fileName, extension)
+                ;
 
             // ReSharper disable once PossibleNullReferenceException
             (new FileInfo(imageFilePath)).Directory.Create();
             File.WriteAllBytes(imageFilePath, bytes);
 
             Debug.Log("Image saved to: " + imageFilePath);
+        }
+
+        private static string BuildFilePath(string folder, string fileName, string extension)
+        {
+            return folder + "/" + MakeValidFileName(fileName + extension);
+        }
+
+        private static string BuildFilePath(string folder, string fileName, DateTime time, string extension)
+        {
+            // Create timestamp with year, month, day, hours, minutes, seconds, and milliseconds
+            // See https://msdn.microsoft.com/en-us/library/8kb3ddd4%28v=vs.110%29.aspx
+            var formatString = "yyyyMMddHHmmssfff";
+            var timeStamp = time.ToString(formatString);
+                        
+            return BuildFilePath(folder, fileName + "." + timeStamp, extension);
         }
 
         private static string MakeValidFileName(string name)


### PR DESCRIPTION
Changed the default location to _PROJECT_ROOT/Screenshots_ instead of _PROJECT_ROOT/Assets/Screenshots_ to prevent unity from importing the newly created screenshots as assets.
Added feature to append a timestamp to the screenshot's name to prevent overriding previously taken screenshots with the same config.
